### PR TITLE
audio will stop now when canceling interaction with note. this will o…

### DIFF
--- a/Assets/Scripts/Zach/NoteBehaviour.cs
+++ b/Assets/Scripts/Zach/NoteBehaviour.cs
@@ -22,29 +22,13 @@ namespace Zach
 
         public void Start()
         {
-            VoiceOver = FMODUnity.RuntimeManager.CreateInstance("event:/Note1_Voiceover");
-            
+            VoiceOver = FMODUnity.RuntimeManager.CreateInstance("event:/Note1_Voiceover");            
         }
 
         public void Update()
         {
-            VoiceOver.getPlaybackState(out VoiceOverPlaybackState);
-            
-        }
-        //public void SetNoteUIActive(bool on)
-        //{
-        //    NoteUI.Value.transform.GetChild(0).gameObject.SetActive(on);
-        //    NoteUI.Value.transform.GetChild(1).gameObject.SetActive(on);
-        //    NoteUI.Value.transform.GetChild(2).gameObject.SetActive(on);
-        //}
-
-        //public void SetUIText()
-        //{
-        //    note.SetIsEnabled(true);
-        //    var textUI = NoteUI.Value.transform.GetChild(1);
-        //    var text = textUI.GetComponent<Text>();
-        //    text.text = note.data;
-        //}
+            VoiceOver.getPlaybackState(out VoiceOverPlaybackState);            
+        }        
 
         public void OnInteract()
         {
@@ -55,11 +39,14 @@ namespace Zach
             NoteInteract.Raise();
             FMODUnity.RuntimeManager.PlayOneShot("event:/notebook_open");
             VoiceOver.start();
-            
-            
+        }
 
-
-
+        public void OnNoteClosed()
+        {
+            if (VoiceOverPlaybackState == FMOD.Studio.PLAYBACK_STATE.PLAYING)
+            {
+               VoiceOver.stop(FMOD.Studio.STOP_MODE.ALLOWFADEOUT);
+            }
         }
     }
 }

--- a/Assets/Scripts/Zach/UIStates/UIContext.cs
+++ b/Assets/Scripts/Zach/UIStates/UIContext.cs
@@ -50,11 +50,11 @@ namespace Zach
             Debug.Log("close whole notebook");
             FMODUnity.RuntimeManager.PlayOneShot("event:/notebook_close");
 
-            Debug.Log(VoiceOverPlaybackState);
-            if (VoiceOverPlaybackState == FMOD.Studio.PLAYBACK_STATE.PLAYING)
-            {
-                voiceOver.stop(FMOD.Studio.STOP_MODE.ALLOWFADEOUT);
-            }
+            //Debug.Log(VoiceOverPlaybackState);
+            //if (VoiceOverPlaybackState == FMOD.Studio.PLAYBACK_STATE.PLAYING)
+            //{
+            //    voiceOver.stop(FMOD.Studio.STOP_MODE.ALLOWFADEOUT);
+            //}
         }
 
         public void ResetContext()

--- a/Assets/Scripts/Zach/UIStates/UINoteState.cs
+++ b/Assets/Scripts/Zach/UIStates/UINoteState.cs
@@ -11,18 +11,16 @@ namespace Zach
         StateEventTransitionSubscription subscription_openPauseMenu;
         StateEventTransitionSubscription subscription_closePauseMenu;
         StateEventTransitionSubscription subscription_closeNote;
-
-        //private FMOD.Studio.EventInstance VoiceOver;
-        
-        
-
         public void OnEnter(IContext context)
         {
-            var uiState = (context as UIContext).Behaviour;
+            
+            var uiState = (context as UIContext).Behaviour;            
             uiState.SetJournalActive(false);
             uiState.SetNoteActive(true);
             Debug.Log("note book interaction scotty");
+            
             FMODUnity.RuntimeManager.PlayOneShot("event:/notebook_selection");
+            
             //VoiceOver.start();
             subscription_closePauseMenu = new StateEventTransitionSubscription
             {
@@ -43,6 +41,8 @@ namespace Zach
 
         public void OnExit(IContext context)
         {
+            var closeNoteEvent = Resources.Load("Events/CloseNote") as GameEvent;
+            closeNoteEvent.Raise();
             subscription_closePauseMenu.UnSubscribe();
             subscription_closeNote.UnSubscribe();
             subscription_openPauseMenu.UnSubscribe();
@@ -56,6 +56,7 @@ namespace Zach
             if (PlayerInput.CancelPressed)
             {
                 context.ChangeState(new UIHiddenState());
+                FMODUnity.RuntimeManager.PlayOneShot("event:/notebook_close");
                 return;
             }
 
@@ -63,9 +64,8 @@ namespace Zach
             {
                 context.ChangeState(new UIJournalState());
                 Debug.Log("CLOSE NOTEBOOK");
-                FMODUnity.RuntimeManager.PlayOneShot("event:/notebook_close");
+                return;
 
-                
             }
         }
     }


### PR DESCRIPTION
…ccur from a noteclose event being raised when exiting the uinotestate. the listener for this event is located on the note object in the scene. that object will then invoke OnNoteClosed to stop the current instance of the FMOD.Studio.EventInstance.